### PR TITLE
Set 'yes' as default value for canBeDistributed field.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Content-Length: 1055
     "lastModified": "2017-05-22T02:59:39.195Z",
     "publishedDate": "2017-04-10T03:29:14.000Z",
     "firstPublishedDate": "2017-04-10T03:29:14.000Z",
-    "canBeDistributed": "verify"
+    "canBeDistributed": "yes"
   },
   {
     "uuid": "8c07916c-2577-37b6-b477-291094f992ee",
@@ -122,7 +122,7 @@ Content-Length: 1055
     "lastModified": "2017-05-22T02:59:39.195Z",
     "publishedDate": "2017-04-10T03:29:14.000Z",
     "firstPublishedDate": "2017-04-10T03:29:14.000Z",
-    "canBeDistributed": "verify"
+    "canBeDistributed": "yes"
   }
 ]
 ```

--- a/queue_test.go
+++ b/queue_test.go
@@ -216,7 +216,7 @@ func TestBuildMessage_Ok(t *testing.T) {
 		},
 		PublishedDate:      "2017-05-18T02:24:25Z",
 		FirstPublishedDate: "2017-05-18T02:24:00Z",
-		CanBeDistributed:   "verify",
+		CanBeDistributed:   "yes",
 		Type:               "ImageSet",
 	}, "2017-05-15T15:54:32.166Z", "tid_test")
 	assert.NoError(t, err, "Error wasn't expected during buildMessage()")
@@ -225,7 +225,7 @@ func TestBuildMessage_Ok(t *testing.T) {
 	assert.Equal(t, actualMsg.Headers["Message-Type"], "cms-content-published")
 	assert.Equal(t, actualMsg.Headers["Content-Type"], "application/json")
 	assert.Equal(t, actualMsg.Headers["Origin-System-Id"], methodeSystemOrigin)
-	assert.Equal(t, actualMsg.Body, `{"contentUri":"http://methode-article-image-set-mapper.svc.ft.com/image-set/model/5a8f3f37-3098-48f7-811a-f69d12f2b1be","payload":{"uuid":"5a8f3f37-3098-48f7-811a-f69d12f2b1be","identifiers":[{"authority":"http://api.ft.com/system/FTCOM-METHODE","identifierValue":"5a8f3f37-3098-48f7-811a-f69d12f2b1be"}],"members":[{"uuid":"8ff1c7f4-a80b-4b8d-8821-b07ff1bfdf87"},{"uuid":"3bea853a-89b8-4831-80b3-8384e962f5dc","maxDisplayWidth":"490px"},{"uuid":"c6eeea75-748e-4b1c-a046-6e4c9d81ff25","minDisplayWidth":"980px"}],"publishReference":"","lastModified":"","publishedDate":"2017-05-18T02:24:25Z","firstPublishedDate":"2017-05-18T02:24:00Z","canBeDistributed":"verify","type":"ImageSet"},"lastModified":"2017-05-15T15:54:32.166Z"}`)
+	assert.Equal(t, actualMsg.Body, `{"contentUri":"http://methode-article-image-set-mapper.svc.ft.com/image-set/model/5a8f3f37-3098-48f7-811a-f69d12f2b1be","payload":{"uuid":"5a8f3f37-3098-48f7-811a-f69d12f2b1be","identifiers":[{"authority":"http://api.ft.com/system/FTCOM-METHODE","identifierValue":"5a8f3f37-3098-48f7-811a-f69d12f2b1be"}],"members":[{"uuid":"8ff1c7f4-a80b-4b8d-8821-b07ff1bfdf87"},{"uuid":"3bea853a-89b8-4831-80b3-8384e962f5dc","maxDisplayWidth":"490px"},{"uuid":"c6eeea75-748e-4b1c-a046-6e4c9d81ff25","minDisplayWidth":"980px"}],"publishReference":"","lastModified":"","publishedDate":"2017-05-18T02:24:25Z","firstPublishedDate":"2017-05-18T02:24:00Z","canBeDistributed":"yes","type":"ImageSet"},"lastModified":"2017-05-15T15:54:32.166Z"}`)
 }
 
 func TestBuildMessages_Ok(t *testing.T) {
@@ -246,7 +246,7 @@ func TestBuildMessages_Ok(t *testing.T) {
 			},
 			PublishedDate:      "2017-05-18T02:24:25Z",
 			FirstPublishedDate: "2017-05-18T02:24:00Z",
-			CanBeDistributed:   "verify",
+			CanBeDistributed:   "yes",
 			Type:               "ImageSet",
 		},
 		JSONImageSet{
@@ -264,7 +264,7 @@ func TestBuildMessages_Ok(t *testing.T) {
 			},
 			PublishedDate:      "2017-05-18T02:24:25Z",
 			FirstPublishedDate: "2017-05-18T02:24:00Z",
-			CanBeDistributed:   "verify",
+			CanBeDistributed:   "yes",
 			Type:               "ImageSet",
 		},
 	}, "2017-05-15T15:54:32.166Z", "tid_test")
@@ -276,13 +276,13 @@ func TestBuildMessages_Ok(t *testing.T) {
 	assert.Equal(t, actualMsgs["5a8f3f37-3098-48f7-811a-f69d12f2b1be"].Headers["Message-Type"], "cms-content-published")
 	assert.Equal(t, actualMsgs["5a8f3f37-3098-48f7-811a-f69d12f2b1be"].Headers["Content-Type"], "application/json")
 	assert.Equal(t, actualMsgs["5a8f3f37-3098-48f7-811a-f69d12f2b1be"].Headers["Origin-System-Id"], methodeSystemOrigin)
-	assert.Equal(t, actualMsgs["5a8f3f37-3098-48f7-811a-f69d12f2b1be"].Body, `{"contentUri":"http://methode-article-image-set-mapper.svc.ft.com/image-set/model/5a8f3f37-3098-48f7-811a-f69d12f2b1be","payload":{"uuid":"5a8f3f37-3098-48f7-811a-f69d12f2b1be","identifiers":[{"authority":"http://api.ft.com/system/FTCOM-METHODE","identifierValue":"5a8f3f37-3098-48f7-811a-f69d12f2b1be"}],"members":[{"uuid":"8ff1c7f4-a80b-4b8d-8821-b07ff1bfdf87"},{"uuid":"3bea853a-89b8-4831-80b3-8384e962f5dc"},{"uuid":"c6eeea75-748e-4b1c-a046-6e4c9d81ff25"}],"publishReference":"","lastModified":"","publishedDate":"2017-05-18T02:24:25Z","firstPublishedDate":"2017-05-18T02:24:00Z","canBeDistributed":"verify","type":"ImageSet"},"lastModified":"2017-05-15T15:54:32.166Z"}`)
+	assert.Equal(t, actualMsgs["5a8f3f37-3098-48f7-811a-f69d12f2b1be"].Body, `{"contentUri":"http://methode-article-image-set-mapper.svc.ft.com/image-set/model/5a8f3f37-3098-48f7-811a-f69d12f2b1be","payload":{"uuid":"5a8f3f37-3098-48f7-811a-f69d12f2b1be","identifiers":[{"authority":"http://api.ft.com/system/FTCOM-METHODE","identifierValue":"5a8f3f37-3098-48f7-811a-f69d12f2b1be"}],"members":[{"uuid":"8ff1c7f4-a80b-4b8d-8821-b07ff1bfdf87"},{"uuid":"3bea853a-89b8-4831-80b3-8384e962f5dc"},{"uuid":"c6eeea75-748e-4b1c-a046-6e4c9d81ff25"}],"publishReference":"","lastModified":"","publishedDate":"2017-05-18T02:24:25Z","firstPublishedDate":"2017-05-18T02:24:00Z","canBeDistributed":"yes","type":"ImageSet"},"lastModified":"2017-05-15T15:54:32.166Z"}`)
 
 	assert.Equal(t, actualMsgs["270c0151-7742-4c1e-b77e-a5557881a042"].Headers["X-Request-Id"], "tid_test")
 	assert.NotEmpty(t, actualMsgs["270c0151-7742-4c1e-b77e-a5557881a042"].Headers["Message-Id"])
 	assert.Equal(t, actualMsgs["270c0151-7742-4c1e-b77e-a5557881a042"].Headers["Message-Type"], "cms-content-published")
 	assert.Equal(t, actualMsgs["270c0151-7742-4c1e-b77e-a5557881a042"].Headers["Content-Type"], "application/json")
 	assert.Equal(t, actualMsgs["270c0151-7742-4c1e-b77e-a5557881a042"].Headers["Origin-System-Id"], methodeSystemOrigin)
-	assert.Equal(t, actualMsgs["270c0151-7742-4c1e-b77e-a5557881a042"].Body, `{"contentUri":"http://methode-article-image-set-mapper.svc.ft.com/image-set/model/270c0151-7742-4c1e-b77e-a5557881a042","payload":{"uuid":"270c0151-7742-4c1e-b77e-a5557881a042","identifiers":[{"authority":"http://api.ft.com/system/FTCOM-METHODE","identifierValue":"270c0151-7742-4c1e-b77e-a5557881a042"}],"members":[{"uuid":"667ee7f3-4f58-4080-a6f9-9b16b633dea8"},{"uuid":"a0513a50-08d1-43f6-af2b-7e7dc4d40b31"},{"uuid":"47e5a693-cd39-4ede-a016-244e6413a7fa"}],"publishReference":"","lastModified":"","publishedDate":"2017-05-18T02:24:25Z","firstPublishedDate":"2017-05-18T02:24:00Z","canBeDistributed":"verify","type":"ImageSet"},"lastModified":"2017-05-15T15:54:32.166Z"}`)
+	assert.Equal(t, actualMsgs["270c0151-7742-4c1e-b77e-a5557881a042"].Body, `{"contentUri":"http://methode-article-image-set-mapper.svc.ft.com/image-set/model/270c0151-7742-4c1e-b77e-a5557881a042","payload":{"uuid":"270c0151-7742-4c1e-b77e-a5557881a042","identifiers":[{"authority":"http://api.ft.com/system/FTCOM-METHODE","identifierValue":"270c0151-7742-4c1e-b77e-a5557881a042"}],"members":[{"uuid":"667ee7f3-4f58-4080-a6f9-9b16b633dea8"},{"uuid":"a0513a50-08d1-43f6-af2b-7e7dc4d40b31"},{"uuid":"47e5a693-cd39-4ede-a016-244e6413a7fa"}],"publishReference":"","lastModified":"","publishedDate":"2017-05-18T02:24:25Z","firstPublishedDate":"2017-05-18T02:24:00Z","canBeDistributed":"yes","type":"ImageSet"},"lastModified":"2017-05-15T15:54:32.166Z"}`)
 
 }

--- a/xmlImageSetToJSONMapper.go
+++ b/xmlImageSetToJSONMapper.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	methodeAuthority  = "http://api.ft.com/system/FTCOM-METHODE"
-	verify            = "verify"
+	canBeDistributedYes            = "yes"
 	methodeDateFormat = "20060102150405"
 	uppDateFormat     = "2006-01-02T03:04:05.000Z0700"
 	imageSetType      = "ImageSet"
@@ -50,7 +50,7 @@ func (m defaultImageSetToJSONMapper) Map(xmlImageSets []XMLImageSet, attributes 
 			},
 			PublishedDate:      publishedDate.Format(uppDateFormat),
 			FirstPublishedDate: firstPublishedDate.Format(uppDateFormat),
-			CanBeDistributed:   verify,
+			CanBeDistributed:   canBeDistributedYes,
 			LastModified:       lastModified,
 			PublishReference:   publishReference,
 			Type:               imageSetType,

--- a/xmlImageSetToJSONMapper_test.go
+++ b/xmlImageSetToJSONMapper_test.go
@@ -71,7 +71,7 @@ func TestXMLJSONMap_Ok(t *testing.T) {
 			LastModified:       "2017-05-17T13:46:01.100Z",
 			PublishedDate:      "2017-05-18T02:24:25.000Z",
 			FirstPublishedDate: "2017-05-18T02:24:00.000Z",
-			CanBeDistributed:   "verify",
+			CanBeDistributed:   "yes",
 			Type:               "ImageSet",
 		},
 		JSONImageSet{
@@ -99,7 +99,7 @@ func TestXMLJSONMap_Ok(t *testing.T) {
 			LastModified:       "2017-05-17T13:46:01.100Z",
 			PublishedDate:      "2017-05-18T02:24:25.000Z",
 			FirstPublishedDate: "2017-05-18T02:24:00.000Z",
-			CanBeDistributed:   "verify",
+			CanBeDistributed:   "yes",
 			Type:               "ImageSet",
 		},
 	}
@@ -147,7 +147,7 @@ func TestXMLJSONMap_LessThan3(t *testing.T) {
 			LastModified:       "2017-05-17T13:46:01.100Z",
 			PublishedDate:      "2017-05-18T02:24:25.000Z",
 			FirstPublishedDate: "2017-05-18T02:24:00.000Z",
-			CanBeDistributed:   "verify",
+			CanBeDistributed:   "yes",
 			Type:               "ImageSet",
 		},
 	}


### PR DESCRIPTION
- Image models will have canBeDistributed value coming from Methode, so we let the sets always be distributable and images within them will be distributable based on their specific canBeDistributed field value
- Specs doc: https://docs.google.com/a/ft.com/document/d/13cknlV2wbqQXa90q5jw9XF12brOC8g_rXDlMGJAT0ys/edit?usp=sharing
- Dev tests performed in video cluster