### PR TITLE
Increase memory limit to 256Mi for K8S

### DIFF
--- a/helm/methode-article-image-set-mapper/values.yaml
+++ b/helm/methode-article-image-set-mapper/values.yaml
@@ -10,7 +10,7 @@ image:
   pullPolicy: IfNotPresent
 resources:
   limits:
-    memory: 64Mi
+    memory: 256Mi
 env:
   Q_GROUP: ""
   Q_READ_TOPIC: ""


### PR DESCRIPTION
- in the K8S prod clusters we have been experiencing a lot of OOM issues with MAISM, so we ran the service with 256Mi limit for a few days and the OOM issues didn't appear again